### PR TITLE
[ci skip] Fix errorneous conda-forge.yml

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,5 +1,7 @@
 bot:
   automerge: true
+  # https://conda-forge.org/docs/maintainer/conda_forge_yml.html#bot
+  inspection: hint
 build_platform:
   linux_aarch64: linux_64
   linux_ppc64le: linux_64
@@ -17,6 +19,3 @@ test: native_and_emulated
 test_on_native_only: true
 conda_build:
   pkg_format: '2'
-bot:
-  # https://conda-forge.org/docs/maintainer/conda_forge_yml.html#bot
-  inspection: hint


### PR DESCRIPTION
This causes the @regro-cf-autotick-bot to hiccup on this feedstock.